### PR TITLE
Add error handling for JSON parse in admin-secure

### DIFF
--- a/admin-secure.html
+++ b/admin-secure.html
@@ -129,7 +129,13 @@
 
     function removeItem(index) {
       const textarea = document.getElementById("jsonInput");
-      let items = JSON.parse(textarea.value);
+      let items = [];
+      try {
+        items = JSON.parse(textarea.value);
+      } catch (e) {
+        alert("Error parsing items. Resetting list.");
+        items = [];
+      }
       items.splice(index, 1);
       textarea.value = JSON.stringify(items, null, 2);
       buildEditor(items);


### PR DESCRIPTION
## Summary
- wrap `JSON.parse` in `removeItem` with try/catch
- alert and reset list if parsing fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68522490df648326911f69a2b42e3e61