### PR TITLE
Add Jest tests for firebase auth helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 LOVERS PWA v1.4c-debug-fix1 with full comments, fixed function scope, validated Firebase syntax, and global exposure.
+
+## Testing
+
+Install dependencies once with `npm install`, then run tests using:
+
+```bash
+npm test
+```

--- a/firebase-auth.test.js
+++ b/firebase-auth.test.js
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+// Jest tests for firebase-auth.js
+
+describe('firebase-auth helpers', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('signIn logs expected message', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    require('./firebase-auth.js');
+    window.signIn();
+    expect(logSpy).toHaveBeenCalledWith('signIn called');
+    logSpy.mockRestore();
+  });
+
+  test('signOut logs expected message', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    require('./firebase-auth.js');
+    window.signOut();
+    expect(logSpy).toHaveBeenCalledWith('signOut called');
+    logSpy.mockRestore();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "lovers-pwa-clean",
+  "version": "1.0.0",
+  "description": "LOVERS PWA v1.4c-debug-fix1",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}


### PR DESCRIPTION
## Summary
- add npm config with Jest
- ignore build artifacts
- test `signIn` and `signOut`
- document how to run tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852249b29688326a2538012da0fc4aa